### PR TITLE
Wrap LiveEditor code in a div

### DIFF
--- a/core/src/LiveEditor.js
+++ b/core/src/LiveEditor.js
@@ -37,7 +37,7 @@ class Editor extends Component {
           code={this.state.code}
           transformCode={code => `
             <ThemeProvider theme={theme}>
-              ${code}
+              <div>${code}</div>
             </ThemeProvider>
           `}
         >


### PR DESCRIPTION
This will allow users to not have to wrap editor
code manually since the ThemeProvider only permits
a single child.