### PR TITLE
Make basename configurable

### DIFF
--- a/core/examples/Library.js
+++ b/core/examples/Library.js
@@ -37,7 +37,7 @@ import {
 
 const Demo = props => (
   <Provider>
-    <Library>
+    <Library baseUrl="/Library">
       <Example name="Heading">
         <Heading>Heading</Heading>
       </Example>

--- a/core/examples/Library.js
+++ b/core/examples/Library.js
@@ -37,7 +37,7 @@ import {
 
 const Demo = props => (
   <Provider>
-    <Library baseUrl="/Library">
+    <Library basename="/Library">
       <Example name="Heading">
         <Heading>Heading</Heading>
       </Example>

--- a/core/src/Library.js
+++ b/core/src/Library.js
@@ -11,11 +11,6 @@ import {
 } from 'react-router-dom'
 import { Grid, Box } from './ui'
 
-const toUrl = (base, component) => {
-  const joinStr = base.endsWith('/') ? '' : '/'
-  return [base, component].join(joinStr)
-}
-
 const Root = nano('div')({
   display: 'flex',
   alignItems: 'flex-start',
@@ -74,10 +69,20 @@ const Router = typeof document !== 'undefined'
   : StaticRouter
 
 export class Library extends React.Component {
+  static propTypes = {
+    baseUrl: PropTypes.string
+  }
+
+  static defaultProps = {
+    baseUrl: '/'
+  }
+
   render () {
+    const { baseUrl, ...props } = this.props
+
     return (
-      <Router context={{}}>
-        <LibraryApp {...this.props} />
+      <Router basename={baseUrl} context={{}}>
+        <LibraryApp {...props} />
       </Router>
     )
   }
@@ -88,12 +93,7 @@ const LibraryApp = withRouter(class extends React.Component {
     title: PropTypes.string,
     examples: PropTypes.array,
     renderSideNav: PropTypes.func,
-    renderCard: PropTypes.func,
-    baseUrl: PropTypes.string
-  }
-
-  static defaultProps = {
-    baseUrl: '/'
+    renderCard: PropTypes.func
   }
 
   getExampleChildren = ({ children }) => (
@@ -110,15 +110,14 @@ const LibraryApp = withRouter(class extends React.Component {
     const {
       title,
       renderSideNav,
-      renderCard,
-      baseUrl
+      renderCard
     } = this.props
 
     const examples = this.props.examples || this.getExampleChildren(this.props)
 
     const sidenav = typeof renderSideNav === 'function'
       ? renderSideNav({ ...this.state, title, examples })
-      : <SideNav title={title} examples={examples} baseUrl={baseUrl} />
+      : <SideNav title={title} examples={examples} />
 
     return (
       <Root>
@@ -128,13 +127,13 @@ const LibraryApp = withRouter(class extends React.Component {
         <Main>
           <Route
             exact
-            path={baseUrl}
+            path='/'
             render={() => (
               <Grid>
                 {examples.map(example => (
                   <Card
                     key={example.name}
-                    to={toUrl(baseUrl, example.name)}>
+                    to={'/' + example.name}>
                     {typeof renderCard === 'function'
                       ? renderCard(example)
                       : (
@@ -151,7 +150,7 @@ const LibraryApp = withRouter(class extends React.Component {
           {examples.map(example => (
             <Route
               key={example.name}
-              path={toUrl(baseUrl, example.name)}
+              path={'/' + example.name}
               render={() => (
                 <Box p={2}>
                   {example.element}
@@ -179,19 +178,18 @@ class SideNav extends React.Component {
   render() {
     const {
       examples,
-      title,
-      baseUrl
+      title
     } = this.props
 
     return (
       <React.Fragment>
-        <NavItem exact to={baseUrl}>
+        <NavItem exact to='/'>
           {title}
         </NavItem>
         {examples.map(example => (
           <NavItem
             key={example.name}
-            to={toUrl(baseUrl, example.name)}>
+            to={'/' + example.name}>
             {example.name}
           </NavItem>
         ))}

--- a/core/src/Library.js
+++ b/core/src/Library.js
@@ -70,18 +70,18 @@ const Router = typeof document !== 'undefined'
 
 export class Library extends React.Component {
   static propTypes = {
-    baseUrl: PropTypes.string
+    basename: PropTypes.string
   }
 
   static defaultProps = {
-    baseUrl: '/'
+    basename: '/'
   }
 
   render () {
-    const { baseUrl, ...props } = this.props
+    const { basename, ...props } = this.props
 
     return (
-      <Router basename={baseUrl} context={{}}>
+      <Router basename={basename} context={{}}>
         <LibraryApp {...props} />
       </Router>
     )

--- a/core/src/Library.js
+++ b/core/src/Library.js
@@ -118,7 +118,7 @@ const LibraryApp = withRouter(class extends React.Component {
 
     const sidenav = typeof renderSideNav === 'function'
       ? renderSideNav({ ...this.state, title, examples })
-      : <SideNav title={title} examples={examples} />
+      : <SideNav title={title} examples={examples} baseUrl={baseUrl} />
 
     return (
       <Root>
@@ -151,7 +151,7 @@ const LibraryApp = withRouter(class extends React.Component {
           {examples.map(example => (
             <Route
               key={example.name}
-              path={'/' + example.name}
+              path={toUrl(baseUrl, example.name)}
               render={() => (
                 <Box p={2}>
                   {example.element}
@@ -179,18 +179,19 @@ class SideNav extends React.Component {
   render() {
     const {
       examples,
-      title
+      title,
+      baseUrl
     } = this.props
 
     return (
       <React.Fragment>
-        <NavItem exact to='/'>
+        <NavItem exact to={baseUrl}>
           {title}
         </NavItem>
         {examples.map(example => (
           <NavItem
             key={example.name}
-            to={'/' + example.name}>
+            to={toUrl(baseUrl, example.name)}>
             {example.name}
           </NavItem>
         ))}

--- a/core/src/Library.js
+++ b/core/src/Library.js
@@ -11,6 +11,11 @@ import {
 } from 'react-router-dom'
 import { Grid, Box } from './ui'
 
+const toUrl = (base, component) => {
+  const joinStr = base.endsWith('/') ? '' : '/'
+  return [base, component].join(joinStr)
+}
+
 const Root = nano('div')({
   display: 'flex',
   alignItems: 'flex-start',
@@ -83,7 +88,12 @@ const LibraryApp = withRouter(class extends React.Component {
     title: PropTypes.string,
     examples: PropTypes.array,
     renderSideNav: PropTypes.func,
-    renderCard: PropTypes.func
+    renderCard: PropTypes.func,
+    baseUrl: PropTypes.string
+  }
+
+  static defaultProps = {
+    baseUrl: '/'
   }
 
   getExampleChildren = ({ children }) => (
@@ -101,6 +111,7 @@ const LibraryApp = withRouter(class extends React.Component {
       title,
       renderSideNav,
       renderCard,
+      baseUrl
     } = this.props
 
     const examples = this.props.examples || this.getExampleChildren(this.props)
@@ -117,13 +128,13 @@ const LibraryApp = withRouter(class extends React.Component {
         <Main>
           <Route
             exact
-            path='/'
+            path={baseUrl}
             render={() => (
               <Grid>
                 {examples.map(example => (
                   <Card
                     key={example.name}
-                    to={'/' + example.name}>
+                    to={toUrl(baseUrl, example.name)}>
                     {typeof renderCard === 'function'
                       ? renderCard(example)
                       : (

--- a/core/src/Library.js
+++ b/core/src/Library.js
@@ -69,14 +69,6 @@ const Router = typeof document !== 'undefined'
   : StaticRouter
 
 export class Library extends React.Component {
-  static propTypes = {
-    basename: PropTypes.string
-  }
-
-  static defaultProps = {
-    basename: '/'
-  }
-
   render () {
     const { basename, ...props } = this.props
 


### PR DESCRIPTION
This is useful when adding a Kit Library to an existing app at it's own url. Please note that when this approach is used the Kit section should be bundle split so it doesn't add to the primary production bundle for an app.