### PR TITLE
Ensure library routing plays nice with next.js

### DIFF
--- a/core/src/Library.js
+++ b/core/src/Library.js
@@ -87,7 +87,7 @@ const LibraryApp = withRouter(
 
     getExampleChildren = ({ children }) =>
       React.Children.toArray(children)
-        .filter(c => c.type === Example)
+        .filter(c => c.type._kitLibraryExample)
         .filter(c => !!c.props.name)
         .map(c => ({
           name: c.props.name,
@@ -172,6 +172,7 @@ class SideNav extends React.Component {
 }
 
 export class Example extends React.Component {
+  static _kitLibraryExample = true
   static propTypes = {
     name: PropTypes.string.isRequired
   }

--- a/templates/next/pages/kit.js
+++ b/templates/next/pages/kit.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from 'standard-components'
-import { Library, Example, Cartesian } from '@compositor/kit'
+import { Library, Example } from '@compositor/kit'
 
 export default props => (
   <Library basename="/kit">


### PR DESCRIPTION
In order to find Example components to display we
check them for equivalence with the local instance of
the Example function.

We now use a static property so that our Example
check is more robust.