### PR TITLE
fix babel-runtime

### DIFF
--- a/cli/lib/dev.js
+++ b/cli/lib/dev.js
@@ -26,9 +26,11 @@ module.exports = opts => {
               'babel-preset-react',
             ].map(require.resolve),
             plugins: [
-              'babel-plugin-macros',
-              'babel-plugin-transform-runtime'
-            ].map(require.resolve)
+              require.resolve('babel-plugin-macros'),
+              [require.resolve('babel-plugin-transform-runtime'), {
+                moduleName: path.join(__dirname, '../node_modules/babel-runtime')
+              }]
+            ]
           }
         }
       ],


### PR DESCRIPTION
try fix path to babel-runtime

[docs](https://babeljs.io/docs/plugins/transform-runtime/#modulename)