### PR TITLE
Use hash router in Library component

### DIFF
--- a/core/__tests__/__snapshots__/Library.js.snap
+++ b/core/__tests__/__snapshots__/Library.js.snap
@@ -19,8 +19,9 @@ exports[`Library renders 1`] = `
       class="nanolgtq4w"
     >
       <a
-        class="nano19oao6z"
-        href="/"
+        aria-current="page"
+        class="nano19oao6z active"
+        href="#/"
       >
         Kit
       </a>
@@ -33,7 +34,16 @@ exports[`Library renders 1`] = `
     </style>
     <div
       class="nano1pfbsnd"
-    />
+    >
+      <div
+        class="nano1moj4mh"
+        height="192"
+        width="256"
+      />
+      <style>
+        .nano1moj4mh{display:grid}.nano1moj4mh{grid-template-columns:repeat(auto-fit, minmax(256px, 1fr))}.nano1moj4mh{grid-auto-rows:192px}
+      </style>
+    </div>
     <style>
       .nano1pfbsnd{flex:1 1 auto;height:100vh;overflow-y:auto;-webkit-overflow-scrolling:touch}
     </style>

--- a/core/examples/Library.js
+++ b/core/examples/Library.js
@@ -38,9 +38,7 @@ import {
 
 const Demo = props => (
   <Provider>
-    <Library
-      useFrame={false}
-      basename="/Library">
+    <Library useFrame={false}>
 
       {/* renders in iframe when useFrame is true */}
       <Head>

--- a/core/src/Library.js
+++ b/core/src/Library.js
@@ -2,8 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import nano from 'nano-style'
 import {
-  BrowserRouter,
-  StaticRouter,
+  HashRouter,
   Route,
   NavLink,
   Link,
@@ -64,16 +63,14 @@ const NavItem = nano(NavLink)({
   }
 })
 
-const Router = typeof document !== 'undefined' ? BrowserRouter : StaticRouter
-
 export class Library extends React.Component {
   render() {
     const { basename, ...props } = this.props
 
     return (
-      <Router basename={basename} context={{}}>
+      <HashRouter basename={basename}>
         <LibraryApp {...props} />
-      </Router>
+      </HashRouter>
     )
   }
 }


### PR DESCRIPTION
I *think* this is probably a better solution for the Library component, considering all the conflicting routing situations we've seen so far