### PR TITLE
add "container" prop to Cartesian

### DIFF
--- a/core/__tests__/Cartesian.js
+++ b/core/__tests__/Cartesian.js
@@ -1,25 +1,45 @@
-import React from 'react'
-import styled from 'styled-components'
-import { render } from 'react-testing-library'
-import { color, space, fontSize } from 'styled-system'
+import React from 'react';
+import styled from 'styled-components';
+import { render } from 'react-testing-library';
+import { color, space, fontSize } from 'styled-system';
 
-import { Cartesian } from '../src'
+import { Cartesian } from '../src';
 
 const buttonProps = {
   children: 'Hello, world!',
   fontSize: [1, 2, 3],
   px: [2, 3],
-  backgroundColor: ['pink', 'tomato', 'purple']
-}
+  backgroundColor: ['pink', 'tomato', 'purple'],
+};
 
 const Button = styled.a`
   ${color}
   ${fontSize}
   ${space}
-`
+`;
+
+const Container = styled.div`
+  padding: 1rem;
+`;
 
 test('Cartesian renders all examples', () => {
-  const { container } = render(<Cartesian {...buttonProps} component={Button} />)
+  const { container } = render(
+    <Cartesian {...buttonProps} component={Button} />,
+  );
 
-  expect(container).toMatchSnapshot()
-})
+  expect(container).toMatchSnapshot();
+});
+
+test('Cartesian renders all examples in a container', () => {
+  const { getByTestId, container } = render(
+    <Cartesian
+      {...buttonProps}
+      component={Button}
+      container={() => <Container data-testid="container" />}
+    />,
+  );
+
+  const containerNode = getByTestId('container');
+  expect(containerNode.nodeName).toBe('DIV');
+  expect(container).toMatchSnapshot();
+});

--- a/core/__tests__/__snapshots__/Cartesian.js.snap
+++ b/core/__tests__/__snapshots__/Cartesian.js.snap
@@ -112,3 +112,80 @@ exports[`Cartesian renders all examples 1`] = `
   </a>
 </div>
 `;
+
+exports[`Cartesian renders all examples in a container 1`] = `
+<div>
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+  <div
+    class="sc-bwzfXH UBTUY"
+    data-testid="container"
+  />
+</div>
+`;

--- a/core/src/Cartesian.js
+++ b/core/src/Cartesian.js
@@ -11,8 +11,8 @@ export default ({ component, container, ...props }) => {
     return (
       <Fragment>
         {combinations.map((props, i) => (
-          <Container>
-            <Component key={i} {...props} />
+          <Container key={i} >
+            <Component {...props} />
           </Container>
         ))}
       </Fragment>

--- a/core/src/Cartesian.js
+++ b/core/src/Cartesian.js
@@ -1,27 +1,18 @@
 import React, { Fragment } from 'react'
 import { cartesianProduct } from './util'
 
-export default ({ component, container, ...props }) => {
+export default ({ component, container = Fragment, ...props }) => {
   const combinations = cartesianProduct(props)
   const Component = component
-  
-  if (container) {
-    const Container = container
-
-    return (
-      <Fragment>
-        {combinations.map((props, i) => (
-          <Container key={i} >
-            <Component {...props} />
-          </Container>
-        ))}
-      </Fragment>
-    )
-  }
+  const Container = container
   
   return (
     <Fragment>
-      {combinations.map((props, i) => <Component key={i} {...props} />)}
+      {combinations.map((props, i) => (
+        <Container key={i} >
+          <Component {...props} />
+        </Container>
+      ))}
     </Fragment>
   )
 }

--- a/core/src/Cartesian.js
+++ b/core/src/Cartesian.js
@@ -1,10 +1,24 @@
 import React, { Fragment } from 'react'
 import { cartesianProduct } from './util'
 
-export default ({ component, ...props }) => {
+export default ({ component, container, ...props }) => {
   const combinations = cartesianProduct(props)
   const Component = component
+  
+  if (container) {
+    const Container = container
 
+    return (
+      <Fragment>
+        {combinations.map((props, i) => (
+          <Container>
+            <Component key={i} {...props} />
+          </Container>
+        ))}
+      </Fragment>
+    )
+  }
+  
   return (
     <Fragment>
       {combinations.map((props, i) => <Component key={i} {...props} />)}


### PR DESCRIPTION
Allow the consumer to provide an optional `container` prop. This prop  is the same type as the `component` prop and behaves the same way. The `container` prop is a way for consumers to control the way each child of the Cartesian component may look. I anticipate this being used primarily for spacing and layout, when the product of the cartesian component does not have any opinions about its container.

I ran into this need here:

```jsx
<Cartesian
  component={Button}
  type={['normal', 'medium', 'dark']}
>
  {['Short', 'Really Really Long Label', 'Medium Label']}
</Cartesian>
```

![image](https://user-images.githubusercontent.com/582828/41805197-105d00f0-7673-11e8-8419-82d3897b081a.png)

I desired this output, and in order to get it I have to be allowed inside of `Cartesian`'s `.map` fn. The only way I can see is the pass a prop:

```jsx
const Wrap = withTheme(
  emotion.View(({ theme: t }) => ({
    padding: t.size(1),
  })),
);

…

<Cartesian
  container={Wrap}
  component={Button}
  type={['normal', 'medium', 'dark']}
>
  {['Short', 'Really Really Long Label', 'Medium Label']}
</Cartesian>
```

![image](https://user-images.githubusercontent.com/582828/41805212-772b3dc4-7673-11e8-84c9-5dad73cee830.png)

Any interest in adding something like this? as far as I can tell there's no way to do it from user-land as it currently stands.