### PR TITLE
[WIP] add props table to docs

### DIFF
--- a/docs/Cartesian.md
+++ b/docs/Cartesian.md
@@ -1,14 +1,19 @@
-
 # Cartesian
 
 Display the cartesian product of component props
 
 ![](images/cartesian.png)
 
+| _Prop_    | _type_ | _default_   | _description_                                            |
+| --------- | ------ | ----------- | -------------------------------------------------------- |
+| component | Node   | `undefined` | The component to apply the cartesian product to          |
+| container | Node   | `Fragment`  | A component to wrap the `component` prop in, for display |
+| children  | Array  | `undefined` | each child you'd like as a part of the product           |
+
 ```jsx
-import React from 'react'
-import { Cartesian } from '@compositor/kit'
-import Button from '../src/Button'
+import React from 'react';
+import { Cartesian } from '@compositor/kit';
+import Button from '../src/Button';
 
 export default props => (
   <Cartesian
@@ -18,5 +23,5 @@ export default props => (
     bg={['blue', 'pink', 'tomato', 'purple']}
     children={['Hello, world!', 'Beep']}
   />
-)
+);
 ```


### PR DESCRIPTION
add a props table to each component's docs.

as mentioned in [#197](https://github.com/c8r/kit/pull/197#issuecomment-399711318)

this is a WIP, I'll remove the [WIP] from the title when its' ready for review - just wanted to throw this out there to start the discussion. I'm sure there will be tweaks to language and presentation.