### PR TITLE
Don't spread props onto React.Fragment

### DIFF
--- a/core/src/Library.js
+++ b/core/src/Library.js
@@ -221,11 +221,13 @@ class SideNav extends React.Component {
 export class Example extends React.Component {
   static _kitLibraryExample = true
   static propTypes = {
-    name: PropTypes.string.isRequired
+    name: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired
   }
 
   render() {
-    return <React.Fragment {...this.props} />
+    const { children } = this.props
+    return <React.Fragment>{children}</React.Fragment>
   }
 }
 


### PR DESCRIPTION
Fixes warning:

```
Warning: Invalid prop `name` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.
          in React.Fragment (created by Example)
          in Example
```